### PR TITLE
Added src directory resolving on Webpack config

### DIFF
--- a/src/actions/sessionActions.js
+++ b/src/actions/sessionActions.js
@@ -1,6 +1,6 @@
 import * as types from './actionTypes';
-import sessionApi from '../api/sessionApi';
-import * as session from '../services/sessionService';
+import sessionApi from 'api/sessionApi';
+import * as session from 'services/sessionService';
 import { SubmissionError } from 'redux-form';
 
 export const loginSuccess = () => {

--- a/src/actions/sessionActions.spec.js
+++ b/src/actions/sessionActions.spec.js
@@ -1,12 +1,12 @@
 import { expect } from 'chai';
-import * as sessionActions from '../actions/sessionActions';
-import * as types from '../actions/actionTypes';
+import * as sessionActions from 'actions/sessionActions';
+import * as types from 'actions/actionTypes';
 import thunk from 'redux-thunk';
 import nock from 'nock';
 import configureMockStore from 'redux-mock-store';
-import * as consts from '../constants/apiConstants.js';
-import initialState from '../reducers/initialState';
-import rootReducer from '../reducers';
+import * as consts from 'constants/apiConstants.js';
+import initialState from 'reducers/initialState';
+import rootReducer from 'reducers';
 import { createStore } from 'redux';
 
 describe('Actions::Session', () => {

--- a/src/actions/signUpActions.js
+++ b/src/actions/signUpActions.js
@@ -1,6 +1,6 @@
 import * as types from './actionTypes';
-import sessionApi from '../api/sessionApi';
-import * as session from '../services/sessionService';
+import sessionApi from 'api/sessionApi';
+import * as session from 'services/sessionService';
 import { SubmissionError } from 'redux-form';
 
 export const signUpSuccess = () => {

--- a/src/actions/signUpActions.spec.js
+++ b/src/actions/signUpActions.spec.js
@@ -1,12 +1,12 @@
 import { expect } from 'chai';
-import * as signUpActions from '../actions/signUpActions';
-import * as types from '../actions/actionTypes';
+import * as signUpActions from 'actions/signUpActions';
+import * as types from 'actions/actionTypes';
 import thunk from 'redux-thunk';
 import nock from 'nock';
 import configureMockStore from 'redux-mock-store';
-import * as consts from '../constants/apiConstants.js';
-import initialState from '../reducers/initialState';
-import rootReducer from '../reducers';
+import * as consts from 'constants/apiConstants.js';
+import initialState from 'reducers/initialState';
+import rootReducer from 'reducers';
 import { createStore } from 'redux';
 
 describe('Actions::SignUp', () => {

--- a/src/api/apiService.js
+++ b/src/api/apiService.js
@@ -1,5 +1,5 @@
 import fetch from 'isomorphic-fetch';
-import * as session from '../services/sessionService';
+import * as session from 'services/sessionService';
 import { browserHistory } from 'react-router';
 import humps from 'humps';
 

--- a/src/api/sessionApi.js
+++ b/src/api/sessionApi.js
@@ -1,5 +1,5 @@
 import api from './apiService.js';
-import * as consts from '../constants/apiConstants.js';
+import * as consts from 'constants/apiConstants.js';
 
 class Session {
   static login(user) {

--- a/src/components/session/LoginForm.js
+++ b/src/components/session/LoginForm.js
@@ -1,7 +1,7 @@
 import React, { PropTypes } from 'react';
 import { Field, reduxForm } from 'redux-form';
-import Input from '../common/Input';
-import * as constraints from '../../utils/constraints';
+import Input from 'components/common/Input';
+import * as constraints from 'utils/constraints';
 
 const LoginForm = ({ handleSubmit, error }) => {
   return (

--- a/src/components/session/LogoutButton.js
+++ b/src/components/session/LogoutButton.js
@@ -2,7 +2,7 @@ import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { browserHistory } from 'react-router';
-import * as sessionActions from '../../actions/sessionActions';
+import * as sessionActions from 'actions/sessionActions';
 
 class LogoutButton extends Component {
   constructor(props, context) {

--- a/src/components/user/SignUpForm.js
+++ b/src/components/user/SignUpForm.js
@@ -1,7 +1,7 @@
 import React, { PropTypes } from 'react';
 import { Field, reduxForm } from 'redux-form';
-import Input from '../common/Input';
-import * as constraints from '../../utils/constraints';
+import Input from 'components/common/Input';
+import * as constraints from 'utils/constraints';
 
 const SignUpForm = ({ handleSubmit }) => {
   return (

--- a/src/containers/HomePage.js
+++ b/src/containers/HomePage.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import LogoutButton from '../components/session/LogoutButton';
+import LogoutButton from 'components/session/LogoutButton';
 
 const HomePage = () => {
   return (

--- a/src/containers/LoginPage.js
+++ b/src/containers/LoginPage.js
@@ -2,8 +2,8 @@ import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { browserHistory, Link } from 'react-router';
-import * as sessionActions from '../actions/sessionActions';
-import LoginForm from '../components/session/LoginForm';
+import * as sessionActions from 'actions/sessionActions';
+import LoginForm from 'components/session/LoginForm';
 
 export class LoginPage extends Component {
   constructor(props, context) {

--- a/src/containers/LoginPage.spec.js
+++ b/src/containers/LoginPage.spec.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import { expect } from 'chai';
 import { LoginPage } from './LoginPage';
-import LoginForm from '../components/session/LoginForm';
+import LoginForm from 'components/session/LoginForm';
 
 describe('<LoginPage />', () => {
   it('should contain <LoginForm />', () => {

--- a/src/containers/SignUpPage.js
+++ b/src/containers/SignUpPage.js
@@ -2,8 +2,8 @@ import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { browserHistory } from 'react-router';
-import * as signUpActions from '../actions/signUpActions';
-import SignUpForm from '../components/user/SignUpForm';
+import * as signUpActions from 'actions/signUpActions';
+import SignUpForm from 'components/user/SignUpForm';
 
 class SignUpPage extends Component {
   constructor(props, context) {

--- a/src/reducers/sessionReducer.js
+++ b/src/reducers/sessionReducer.js
@@ -1,4 +1,4 @@
-import * as types from '../actions/actionTypes';
+import * as types from 'actions/actionTypes';
 import initialState from './initialState';
 
 const sessionReducer = (state = initialState.session, action) => {

--- a/src/reducers/sessionReducer.spec.js
+++ b/src/reducers/sessionReducer.spec.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import sessionReducer from './sessionReducer';
-import * as types from '../actions/actionTypes';
+import * as types from 'actions/actionTypes';
 import initialState from './initialState';
 
 describe('Reducer::Session', () => {

--- a/src/reducers/signUpReducer.js
+++ b/src/reducers/signUpReducer.js
@@ -1,4 +1,4 @@
-import * as types from '../actions/actionTypes';
+import * as types from 'actions/actionTypes';
 import initialState from './initialState';
 
 const signUpReducer = (state = initialState.signUp, action) => {

--- a/src/reducers/signUpReducer.spec.js
+++ b/src/reducers/signUpReducer.spec.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import signUpReducer from './signUpReducer';
-import * as types from '../actions/actionTypes';
+import * as types from 'actions/actionTypes';
 import initialState from './initialState';
 
 describe('Reducer::SignUp', () => {

--- a/src/services/sessionService.js
+++ b/src/services/sessionService.js
@@ -1,4 +1,4 @@
-import * as constant from '../constants/apiConstants';
+import * as constant from 'constants/apiConstants';
 import * as localForage from 'localforage';
 
 export const loadSession = () => {

--- a/src/store/configureStore.dev.js
+++ b/src/store/configureStore.dev.js
@@ -4,7 +4,7 @@
 
 import { createStore, compose, applyMiddleware } from 'redux';
 import thunkMiddleware from 'redux-thunk';
-import rootReducer from '../reducers';
+import rootReducer from 'reducers';
 import reduxImmutableStateInvariant from 'redux-immutable-state-invariant';
 
 export default function configureStore(initialState) {

--- a/src/store/configureStore.prod.js
+++ b/src/store/configureStore.prod.js
@@ -1,6 +1,6 @@
 import { createStore, compose, applyMiddleware } from 'redux';
 import thunkMiddleware from 'redux-thunk';
-import rootReducer from '../reducers';
+import rootReducer from 'reducers';
 
 export default function configureStore(initialState) {
   const middewares = [

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -4,7 +4,8 @@ import autoprefixer from 'autoprefixer';
 
 export default {
   resolve: {
-    extensions: ['', '.js', '.jsx']
+    extensions: ['', '.js', '.jsx'],
+    modulesDirectories: ['src', 'node_modules'],
   },
   debug: true,
   devtool: 'eval-source-map', // more info:https://webpack.github.io/docs/build-performance.html#sourcemaps and https://webpack.github.io/docs/configuration.html#devtool

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -13,7 +13,8 @@ const GLOBALS = {
 
 export default {
   resolve: {
-    extensions: ['', '.js', '.jsx']
+    extensions: ['', '.js', '.jsx'],
+    modulesDirectories: ['src', 'node_modules'],
   },
   debug: true,
   devtool: 'source-map', // more info:https://webpack.github.io/docs/build-performance.html#sourcemaps and https://webpack.github.io/docs/configuration.html#devtool


### PR DESCRIPTION
Okay, so I added this and personally, I think the code looks much better using it.

However, we have a couple of situations to solve before we merge this into master. 

1) The first one has to do with the linter triggering the `import/no-unresolved` rule exception on these imports. Here's a related link with a discussion: https://github.com/AtomLinter/linter-eslint/issues/610. I tried some of the suggested methods there, but none of them work.
Also, I want to add, this doesn't have anything to do with Atom since the exceptions are also triggered when running `npm run lint` via CLI.
One possibility would be adding `'import/no-unresolved' :0` to the project's `.eslintrc`, but you may not want to do that. I don't think that's a big deal, but something to discuss.

2) Do we have a AWS bucket for this base to test it? It should work everywhere if we resolve modules using Webpack, as we're doing, but if we want an extra test on AWS, we'll need to set that up, and probably a generic API to connect to.

What's your take on this?