### PR TITLE
401 response redirect handling

### DIFF
--- a/src/api/apiService.js
+++ b/src/api/apiService.js
@@ -28,13 +28,9 @@ const handleErrors = response =>
       return;
     }
 
-    sessionService.loadSession()
-      .then(() => {
-        if (response.status === 401) {
-          sessionService.deleteSession();
-          window.location = routes.login;
-        }
-      }).catch(() => {});
+    if (response.status === 401) {
+      sessionService.deleteSession();
+    }
 
     response.json()
       .then((json) => {


### PR DESCRIPTION
Solves #97 
Always delete session on 401 response, this will cause session state to be refreshed and the redirect will be handled declaratively by PrivateRoute component