### PR TITLE
Fix tests failing without API_URL environemnt variable

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,1 @@
+API_URL=https://mock.com/api/v1

--- a/tools/testSetup.js
+++ b/tools/testSetup.js
@@ -1,6 +1,6 @@
 import Enzyme from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 
-require('dotenv').config({ path: '.env.dev'});
+require('dotenv').config({ path: '.env.test'});
 
 Enzyme.configure({ adapter: new Adapter() });


### PR DESCRIPTION
Tests were failing because nock couldn't find `process.env.API_URL`.
Ideas for a better fix are welcome!