### PR TITLE
Add yarn.lock checksum in dependency cache key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
       - restore_cache:
           name: Restore Yarn Package Cache
           keys:
-            - dependency-cache
+            - dependency-cache-{{ checksum "yarn.lock" }}
       - run:
           name: Install dependencies
           command: yarn
@@ -23,7 +23,7 @@ jobs:
           command: yarn lint
 
       - save_cache:
-          key: dependency-cache
+          key: dependency-cache-{{ checksum "yarn.lock" }}
           paths:
             - ~/.cache/yarn
 


### PR DESCRIPTION
This PR adds a yarn.lock checksum in the dependency cache key. This makes each yarn.lock have a different cache, so if any package changes the build will use a new cache.
[Caches are erased after 30 days,](https://circleci.com/docs/2.0/caching/) so there should be no problem with many key changes. 