### PR TITLE
Remove css, scss and md files from lint-staged task

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     }
   },
   "lint-staged": {
-    "src/**/*.{js,jsx,ts,tsx,json,css,scss,md}": [
+    "src/**/*.{js,jsx,ts,tsx,json}": [
       "prettier --write",
       "yarn lint:fix --quiet",
       "git add"


### PR DESCRIPTION
Make sure pre-commit formatters and linters are only run on JS related files