### PR TITLE
Status reducer

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -15,7 +15,7 @@ import user from 'fixtures/fakeUser';
 import session from 'fixtures/headers';
 import realUser from 'fixtures/realUser';
 import { SUCCESS_CASE } from 'cypressConstants';
-import { saveSession, saveUser } from 'actions/userActions';
+import { loginSuccess, updateSession } from 'actions/userActions';
 
 // Cypress image snapshot
 addMatchImageSnapshotCommand({
@@ -48,8 +48,8 @@ Cypress.Commands.add('loginUser', () => {
   Cypress.log({ name: 'Save user and session data' });
 
   cy.window().its('store').then(store => {
-    store.dispatch(saveSession(session()));
-    store.dispatch(saveUser(user()));
+    store.dispatch(updateSession(session()));
+    store.dispatch(loginSuccess(user()));
   });
 });
 
@@ -66,8 +66,8 @@ Cypress.Commands.add('realLoginUser', () => {
       if (token) {
         const session = { token, uid, client };
         cy.window().its('store').then(store => {
-          store.dispatch(saveSession(session));
-          store.dispatch(saveUser(user));
+          store.dispatch(updateSession(session));
+          store.dispatch(loginSuccess(user));
         });
       }
     }

--- a/src/actions/actionTypes.js
+++ b/src/actions/actionTypes.js
@@ -1,7 +1,16 @@
 // action types
 
-export const SAVE_USER = 'SAVE_USER';
+export const LOGIN = 'LOGIN';
+export const LOGIN_SUCCESS = 'LOGIN_SUCCESS';
+export const LOGIN_REQUEST = 'LOGIN_REQUEST';
+export const LOGIN_ERROR = 'LOGIN_ERROR';
 
-export const SAVE_SESSION = 'SAVE_SESSION';
+export const LOGOUT_REQUEST = 'LOGOUT_REQUEST';
+export const LOGOUT_SUCCESS = 'LOGOUT_SUCCESS';
 
-export const REMOVE_DATA = 'REMOVE_DATA';
+export const UPDATE_SESSION = 'UPDATE_SESSION';
+
+export const SIGNUP = 'SIGNUP';
+export const SIGNUP_REQUEST = 'SIGNUP_REQUEST';
+export const SIGNUP_SUCCESS = 'SIGNUP_SUCCESS';
+export const SIGNUP_ERROR = 'SIGNUP_ERROR';

--- a/src/actions/userActions.js
+++ b/src/actions/userActions.js
@@ -35,10 +35,7 @@ export const login = user => async dispatch => {
     } = await userService.login({ user });
     dispatch(loginSuccess(createdUser));
   } catch (err) {
-    dispatch(loginError());
-    throw new SubmissionError({
-      _error: err.data.error
-    });
+    dispatch(loginError(err.data.error));
   }
 };
 

--- a/src/actions/userActions.js
+++ b/src/actions/userActions.js
@@ -1,22 +1,41 @@
 import { SubmissionError } from 'redux-form';
 
-import { SAVE_SESSION, SAVE_USER, REMOVE_DATA } from 'actions/actionTypes';
+import {
+  LOGIN_REQUEST,
+  LOGIN_SUCCESS,
+  LOGIN_ERROR,
+  LOGOUT_REQUEST,
+  LOGOUT_SUCCESS,
+  SIGNUP_REQUEST,
+  SIGNUP_SUCCESS,
+  SIGNUP_ERROR,
+  UPDATE_SESSION
+} from 'actions/actionTypes';
 import createAction from 'actions/createAction';
 import userService from 'services/userService';
 
-export const saveSession = createAction(SAVE_SESSION);
+export const loginRequest = createAction(LOGIN_REQUEST);
+export const loginSuccess = createAction(LOGIN_SUCCESS);
+export const loginError = createAction(LOGIN_ERROR);
 
-export const saveUser = createAction(SAVE_USER);
+export const signupRequest = createAction(SIGNUP_REQUEST);
+export const signupSuccess = createAction(SIGNUP_SUCCESS);
+export const signupError = createAction(SIGNUP_ERROR);
 
-export const removeData = createAction(REMOVE_DATA);
+export const logoutRequest = createAction(LOGOUT_REQUEST);
+export const logoutSuccess = createAction(LOGOUT_SUCCESS);
+
+export const updateSession = createAction(UPDATE_SESSION);
 
 export const login = user => async dispatch => {
   try {
+    dispatch(loginRequest());
     const {
       data: { user: createdUser }
     } = await userService.login({ user });
-    dispatch(saveUser(createdUser));
+    dispatch(loginSuccess(createdUser));
   } catch (err) {
+    dispatch(loginError());
     throw new SubmissionError({
       _error: err.data.error
     });
@@ -25,8 +44,9 @@ export const login = user => async dispatch => {
 
 export const logout = () => async dispatch => {
   try {
+    dispatch(logoutRequest());
     await userService.logout();
-    dispatch(removeData());
+    dispatch(logoutSuccess());
   } catch (err) {
     throw err.data.error;
   }
@@ -34,11 +54,13 @@ export const logout = () => async dispatch => {
 
 export const signUp = user => async dispatch => {
   try {
+    dispatch(signupRequest());
     const {
       data: { user: createdUser }
     } = await userService.signUp({ user });
-    dispatch(saveUser(createdUser));
+    dispatch(signupSuccess(createdUser));
   } catch (err) {
+    dispatch(signupError());
     throw new SubmissionError(err.data.errors);
   }
 };

--- a/src/api/utils/applyDefaultInterceptors.js
+++ b/src/api/utils/applyDefaultInterceptors.js
@@ -1,4 +1,4 @@
-import { saveSession, logout } from 'actions/userActions';
+import { updateSession, logout } from 'actions/userActions';
 
 const ACCESS_TOKEN = 'access-token';
 const UID = 'uid';
@@ -37,7 +37,7 @@ const defaultResponseInterceptors = store => [
           uid: headers.get(UID),
           client: headers.get(CLIENT)
         };
-        store.dispatch(saveSession(session));
+        store.dispatch(updateSession(session));
       }
     }
     if (response.status === UNAUTHORIZED) {

--- a/src/components/user/LoginForm.js
+++ b/src/components/user/LoginForm.js
@@ -1,12 +1,12 @@
 import React, { memo } from 'react';
-import { func, string } from 'prop-types';
+import { func } from 'prop-types';
 import { Field, reduxForm } from 'redux-form';
 import { useIntl, defineMessages, FormattedMessage } from 'react-intl';
 
 import Loading from 'components/common/Loading';
 import Input from 'components/common/Input';
 import { validations, login } from 'utils/constraints';
-import { LOADING } from 'constants/status';
+import { LOADING, ERROR } from 'constants/status';
 import { useStatus } from 'hooks';
 import { LOGIN } from 'actions/actionTypes';
 
@@ -15,13 +15,13 @@ const messages = defineMessages({
   password: { id: 'login.form.password' }
 });
 
-export const LoginForm = ({ handleSubmit, error }) => {
+export const LoginForm = ({ handleSubmit }) => {
   const intl = useIntl();
-  const { status } = useStatus(LOGIN);
+  const { status, error } = useStatus(LOGIN);
 
   return (
     <form onSubmit={handleSubmit}>
-      {error && <strong>{error}</strong>}
+      {status === ERROR && <strong>{error}</strong>}
       <div>
         <Field
           name="email"
@@ -47,8 +47,7 @@ export const LoginForm = ({ handleSubmit, error }) => {
 };
 
 LoginForm.propTypes = {
-  handleSubmit: func.isRequired,
-  error: string
+  handleSubmit: func.isRequired
 };
 
 export default reduxForm({

--- a/src/components/user/LoginForm.js
+++ b/src/components/user/LoginForm.js
@@ -1,19 +1,24 @@
 import React, { memo } from 'react';
-import { func, string, bool } from 'prop-types';
+import { func, string } from 'prop-types';
 import { Field, reduxForm } from 'redux-form';
 import { useIntl, defineMessages, FormattedMessage } from 'react-intl';
 
 import Loading from 'components/common/Loading';
 import Input from 'components/common/Input';
 import { validations, login } from 'utils/constraints';
+import { LOADING } from 'constants/status';
+import { useStatus } from 'hooks';
+import { LOGIN } from 'actions/actionTypes';
 
 const messages = defineMessages({
   email: { id: 'login.form.email' },
   password: { id: 'login.form.password' }
 });
 
-export const LoginForm = ({ handleSubmit, error, submitting }) => {
+export const LoginForm = ({ handleSubmit, error }) => {
   const intl = useIntl();
+  const { status } = useStatus(LOGIN);
+
   return (
     <form onSubmit={handleSubmit}>
       {error && <strong>{error}</strong>}
@@ -36,14 +41,13 @@ export const LoginForm = ({ handleSubmit, error, submitting }) => {
       <button type="submit">
         <FormattedMessage id="login.form.submit" />
       </button>
-      {submitting && <Loading />}
+      {status === LOADING && <Loading />}
     </form>
   );
 };
 
 LoginForm.propTypes = {
   handleSubmit: func.isRequired,
-  submitting: bool.isRequired,
   error: string
 };
 

--- a/src/components/user/SignUpForm.js
+++ b/src/components/user/SignUpForm.js
@@ -1,11 +1,14 @@
 import React, { memo } from 'react';
-import { func, bool } from 'prop-types';
+import { func } from 'prop-types';
 import { Field, reduxForm } from 'redux-form';
 import { useIntl, defineMessages, FormattedMessage } from 'react-intl';
 
 import Loading from 'components/common/Loading';
 import Input from 'components/common/Input';
 import { validations, signUp } from 'utils/constraints';
+import { LOADING } from 'constants/status';
+import { useStatus } from 'hooks';
+import { SIGNUP } from 'actions/actionTypes';
 
 const messages = defineMessages({
   email: { id: 'login.form.email' },
@@ -13,8 +16,10 @@ const messages = defineMessages({
   passConfirmation: { id: 'signup.form.passconfirmation' }
 });
 
-export const SignUpForm = ({ handleSubmit, submitting }) => {
+export const SignUpForm = ({ handleSubmit }) => {
   const intl = useIntl();
+  const { status } = useStatus(SIGNUP);
+
   return (
     <form onSubmit={handleSubmit}>
       <div>
@@ -44,14 +49,13 @@ export const SignUpForm = ({ handleSubmit, submitting }) => {
       <button type="submit">
         <FormattedMessage id="login.form.submit" />
       </button>
-      {submitting && <Loading />}
+      {status === LOADING && <Loading />}
     </form>
   );
 };
 
 SignUpForm.propTypes = {
-  handleSubmit: func.isRequired,
-  submitting: bool.isRequired
+  handleSubmit: func.isRequired
 };
 
 export default reduxForm({

--- a/src/components/user/SignUpForm.js
+++ b/src/components/user/SignUpForm.js
@@ -6,8 +6,7 @@ import { useIntl, defineMessages, FormattedMessage } from 'react-intl';
 import Loading from 'components/common/Loading';
 import Input from 'components/common/Input';
 import { validations, signUp } from 'utils/constraints';
-import { LOADING } from 'constants/status';
-import { useStatus } from 'hooks';
+import { useLoading } from 'hooks';
 import { SIGNUP } from 'actions/actionTypes';
 
 const messages = defineMessages({
@@ -18,7 +17,7 @@ const messages = defineMessages({
 
 export const SignUpForm = ({ handleSubmit }) => {
   const intl = useIntl();
-  const { status } = useStatus(SIGNUP);
+  const loading = useLoading(SIGNUP);
 
   return (
     <form onSubmit={handleSubmit}>
@@ -49,7 +48,7 @@ export const SignUpForm = ({ handleSubmit }) => {
       <button type="submit">
         <FormattedMessage id="login.form.submit" />
       </button>
-      {status === LOADING && <Loading />}
+      {loading && <Loading />}
     </form>
   );
 };

--- a/src/constants/status.js
+++ b/src/constants/status.js
@@ -1,0 +1,7 @@
+export const NOT_STARTED = 'NOT_STARTED';
+
+export const LOADING = 'LOADING';
+
+export const SUCCESS = 'SUCCESS';
+
+export const ERROR = 'ERROR';

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -1,2 +1,4 @@
 export { default as useSession } from './useSession';
 export { default as useDispatch } from './useDispatch';
+export { default as useLoading } from './useLoading';
+export { default as useStatus } from './useStatus';

--- a/src/hooks/useLoading.js
+++ b/src/hooks/useLoading.js
@@ -1,0 +1,10 @@
+import { useSelector } from 'react-redux';
+import { LOADING } from 'constants/status';
+
+const useLoading = action =>
+  useSelector(({ actionStatus }) => {
+    const { status } = actionStatus[action] || {};
+    return status === LOADING;
+  });
+
+export default useLoading;

--- a/src/hooks/useStatus.js
+++ b/src/hooks/useStatus.js
@@ -1,0 +1,12 @@
+import { useSelector } from 'react-redux';
+
+const useStatus = action =>
+  useSelector(({ actionStatus }) => {
+    const { status, error } = actionStatus[action] || {};
+    return {
+      status,
+      error
+    };
+  });
+
+export default useStatus;

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -5,6 +5,7 @@ import localForage from 'localforage';
 import { persistReducer } from 'redux-persist';
 import autoMergeLevel2 from 'redux-persist/lib/stateReconciler/autoMergeLevel2';
 
+import actionStatus from 'reducers/statusReducer';
 import session from './sessionReducer';
 
 const sessionPersistConfig = {
@@ -18,7 +19,8 @@ const rootReducer = history =>
   combineReducers({
     form,
     session: persistReducer(sessionPersistConfig, session),
-    router: connectRouter(history)
+    router: connectRouter(history),
+    actionStatus
   });
 
 export default rootReducer;

--- a/src/reducers/sessionReducer.js
+++ b/src/reducers/sessionReducer.js
@@ -8,16 +8,17 @@ const initialState = {
 };
 
 const actionHandlers = {
-  [types.SAVE_SESSION]: (state, { payload }) => {
+  [types.LOGIN_SUCCESS]: (state, { payload }) => {
+    state.user = payload;
+  },
+  [types.SIGNUP_SUCCESS]: (state, { payload }) => {
+    state.user = payload;
+  },
+  [types.UPDATE_SESSION]: (state, { payload }) => {
     state.info = payload;
     state.authenticated = true;
   },
-
-  [types.SAVE_USER]: (state, { payload }) => {
-    state.user = payload;
-  },
-
-  [types.REMOVE_DATA]: () => initialState
+  [types.LOGOUT_SUCCESS]: () => initialState
 };
 
 export default createReducer(initialState, actionHandlers);

--- a/src/reducers/statusReducer.js
+++ b/src/reducers/statusReducer.js
@@ -1,0 +1,38 @@
+import { produce } from 'immer';
+import { NOT_STARTED, LOADING, SUCCESS, ERROR } from 'constants/status';
+
+const handleAction = (state, action) => {
+  const { type, error } = action;
+
+  const matchesStart = /(.*)_(REQUEST)/.exec(type);
+  const matchesError = /(.*)_(ERROR)/.exec(type);
+  const matchesReset = /(.*)_(RESET)/.exec(type);
+  const matchesSuccess = /(.*)_(SUCCESS)/.exec(type);
+
+  let status = NOT_STARTED;
+  let key = null;
+
+  if (matchesStart) {
+    const [, requestName] = matchesStart;
+    key = requestName;
+    status = LOADING;
+  } else if (matchesReset) {
+    const [, requestName] = matchesReset;
+    key = requestName;
+    status = NOT_STARTED;
+  } else if (matchesError) {
+    const [, requestName] = matchesError;
+    key = requestName;
+    status = ERROR;
+  } else if (matchesSuccess) {
+    const [, requestName] = matchesSuccess;
+    key = requestName;
+    status = SUCCESS;
+  }
+
+  if (key) state[key] = { status, error };
+
+  return state;
+};
+
+export default (state = {}, action) => produce(state, draft => handleAction(draft, action));

--- a/src/reducers/statusReducer.js
+++ b/src/reducers/statusReducer.js
@@ -2,7 +2,7 @@ import { produce } from 'immer';
 import { NOT_STARTED, LOADING, SUCCESS, ERROR } from 'constants/status';
 
 const handleAction = (state, action) => {
-  const { type, error } = action;
+  const { type, payload } = action;
 
   const matchesStart = /(.*)_(REQUEST)/.exec(type);
   const matchesError = /(.*)_(ERROR)/.exec(type);
@@ -30,7 +30,7 @@ const handleAction = (state, action) => {
     status = SUCCESS;
   }
 
-  if (key) state[key] = { status, error };
+  if (key) state[key] = { status, error: payload };
 
   return state;
 };

--- a/src/reducers/statusReducer.js
+++ b/src/reducers/statusReducer.js
@@ -4,10 +4,10 @@ import { NOT_STARTED, LOADING, SUCCESS, ERROR } from 'constants/status';
 const handleAction = (state, action) => {
   const { type, payload } = action;
 
-  const matchesStart = /(.*)_(REQUEST)/.exec(type);
-  const matchesError = /(.*)_(ERROR)/.exec(type);
-  const matchesReset = /(.*)_(RESET)/.exec(type);
-  const matchesSuccess = /(.*)_(SUCCESS)/.exec(type);
+  const matchesStart = /(.*)_REQUEST/.exec(type);
+  const matchesError = /(.*)_ERROR/.exec(type);
+  const matchesReset = /(.*)_RESET/.exec(type);
+  const matchesSuccess = /(.*)_SUCCESS/.exec(type);
 
   let status = NOT_STARTED;
   let key = null;


### PR DESCRIPTION
## Status Reducer 

Following [this](https://github.com/rootstrap/react-native-base/pull/74) PR in the RN base project

### Tasks 

Added a generic reducer that track the status of every action dispatched. The main goal is to reduce boilerplate and standardise status and error handling in one place.

The status reducer matches against ACTION_(REQUEST|ERROR|SUCCESS|RESET) to define the status of the action between STARTED|NOT_STARTED|LOADING|ERROR.
If the action has an error key, it will be stored alongside the status.

Added hooks to query the store.

This way, we only need to dispatch the correct action types, and we are good to go, the statusReducer takes care of the rest, and you can use the provided hooks useLoading useError and useStatus to query that state for each action.

Used it to show loading in Login and Signup form, and to handle error in the Login form.

### Future work
- Remove redux-forms

PS: thanks @mcousillas6 😁 