### PR TITLE
Switch redux forms for a custom form hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,6 @@ The server is prepared to fetch data directly from the backend before rendering 
 | [PostCSS](https://github.com/postcss/postcss) | Transform styles with JS plugins. Used to autoprefix CSS |
 | [Stylelint](https://github.com/stylelint/stylelint) | Modern CSS linter that helps you enforce consistent conventions and avoid errors in your stylesheets. |
 | [Redux Persist](https://github.com/rt2zz/redux-persist) | Persist and rehydrate your redux store |
-| [ReduxForm](http://redux-form.com/6.4.3/) | Redux-form works with React Redux to enable an html form in React to use Redux to store all of its state. |
 | [Isomorphic Fetch](https://github.com/matthew-andrews/isomorphic-fetch) |  Is a Promise-based mechanism for programatically making web requests in the browser. |
 | [Immer](https://github.com/immerjs/immer) | Allows you to work with immutable state in a more convenient way. |
 | [React Intl](https://github.com/yahoo/react-intl/) | Localization for language support. |

--- a/cypress/stubs/sessionStubs.js
+++ b/cypress/stubs/sessionStubs.js
@@ -37,7 +37,7 @@ export const signUpStub = customUser => ({
     },
     fail: {
       status: UNPROCESSABLE_ENTITY_CODE,
-      response: { errors: { email: ['has already been taken'] } },
+      response: { error: 'Email has already been taken' },
       withHeaders: false
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react_redux_base",
+  "name": "react-redux-base",
   "version": "0.1.0",
   "description": "Rootstrap React Redux Base",
   "engines": {
@@ -55,7 +55,7 @@
   "lint-staged": {
     "src/**/*.{js,jsx,ts,tsx,json}": [
       "prettier --write",
-      "yarn lint:fix --quiet",
+      "eslint --fix webpack/webpack.config.* src",
       "git add"
     ]
   },
@@ -86,7 +86,6 @@
     "react-router-config": "1.0.0-beta.4",
     "react-router-dom": "5.1.0",
     "redux": "4.0.0",
-    "redux-form": "8.2.3",
     "redux-logger": "3.0.6",
     "redux-persist": "5.10.0",
     "redux-thunk": "2.3.0",

--- a/src/actions/userActions.js
+++ b/src/actions/userActions.js
@@ -1,5 +1,3 @@
-import { SubmissionError } from 'redux-form';
-
 import {
   LOGIN_REQUEST,
   LOGIN_SUCCESS,
@@ -57,7 +55,6 @@ export const signUp = user => async dispatch => {
     } = await userService.signUp({ user });
     dispatch(signupSuccess(createdUser));
   } catch (err) {
-    dispatch(signupError());
-    throw new SubmissionError(err.data.errors);
+    dispatch(signupError(err.data.error));
   }
 };

--- a/src/components/common/Input.js
+++ b/src/components/common/Input.js
@@ -1,29 +1,32 @@
 import React from 'react';
-import { string, object } from 'prop-types';
+import { string, arrayOf } from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 
 import { parseInputErrors } from 'utils/helpers';
 
-const Input = ({ input, label, type, placeholder, meta: { touched, error } }) => (
-  <div>
-    {label && <label htmlFor={input.name}>{label}</label>}
+const Input = ({ label, name, errors, ...props }) => {
+  return (
     <div>
-      <input {...input} {...{ placeholder, type }} />
-      {touched && error && (
-        <span>
-          <FormattedMessage id={parseInputErrors(error)} defaultMessage={parseInputErrors(error)} />
-        </span>
-      )}
+      {label && <label htmlFor={name}>{label}</label>}
+      <div>
+        <input name={name} {...props} />
+        {errors && (
+          <span>
+            <FormattedMessage
+              id={parseInputErrors(errors)}
+              defaultMessage={parseInputErrors(errors)}
+            />
+          </span>
+        )}
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
 Input.propTypes = {
-  input: object.isRequired,
+  name: string.isRequired,
   label: string,
-  type: string.isRequired,
-  placeholder: string,
-  meta: object
+  errors: arrayOf(string)
 };
 
 export default Input;

--- a/src/components/user/LoginForm.js
+++ b/src/components/user/LoginForm.js
@@ -1,13 +1,12 @@
 import React, { memo } from 'react';
 import { func } from 'prop-types';
-import { Field, reduxForm } from 'redux-form';
 import { useIntl, defineMessages, FormattedMessage } from 'react-intl';
 
 import Loading from 'components/common/Loading';
 import Input from 'components/common/Input';
-import { validations, login } from 'utils/constraints';
+import { login } from 'utils/constraints';
 import { LOADING, ERROR } from 'constants/status';
-import { useStatus } from 'hooks';
+import { useStatus, useForm, useValidation, useTextInputProps } from 'hooks';
 import { LOGIN } from 'actions/actionTypes';
 
 const messages = defineMessages({
@@ -15,27 +14,43 @@ const messages = defineMessages({
   password: { id: 'login.form.password' }
 });
 
-export const LoginForm = ({ handleSubmit }) => {
+const fields = {
+  email: 'email',
+  password: 'password'
+};
+
+export const LoginForm = ({ onSubmit }) => {
   const intl = useIntl();
   const { status, error } = useStatus(LOGIN);
+  const validator = useValidation(login);
+  const { values, errors, handleValueChange, handleSubmit, handleBlur } = useForm(
+    {
+      onSubmit,
+      validator,
+      validateOnBlur: true
+    },
+    [onSubmit]
+  );
+
+  const inputProps = useTextInputProps({ handleValueChange, handleBlur, values, errors });
 
   return (
     <form onSubmit={handleSubmit}>
       {status === ERROR && <strong>{error}</strong>}
       <div>
-        <Field
+        <Input
           name="email"
-          label={intl.formatMessage(messages.email)}
-          component={Input}
           type="email"
+          label={intl.formatMessage(messages.email)}
+          {...inputProps(fields.email)}
         />
       </div>
       <div>
-        <Field
+        <Input
           name="password"
-          label={intl.formatMessage(messages.password)}
-          component={Input}
           type="password"
+          label={intl.formatMessage(messages.password)}
+          {...inputProps(fields.password)}
         />
       </div>
       <button type="submit">
@@ -47,10 +62,7 @@ export const LoginForm = ({ handleSubmit }) => {
 };
 
 LoginForm.propTypes = {
-  handleSubmit: func.isRequired
+  onSubmit: func.isRequired
 };
 
-export default reduxForm({
-  form: 'login',
-  validate: validations(login, { fullMessages: false })
-})(memo(LoginForm));
+export default memo(LoginForm);

--- a/src/components/user/SignUpForm.js
+++ b/src/components/user/SignUpForm.js
@@ -1,12 +1,12 @@
 import React, { memo } from 'react';
 import { func } from 'prop-types';
-import { Field, reduxForm } from 'redux-form';
 import { useIntl, defineMessages, FormattedMessage } from 'react-intl';
 
 import Loading from 'components/common/Loading';
 import Input from 'components/common/Input';
-import { validations, signUp } from 'utils/constraints';
-import { useLoading } from 'hooks';
+import { signUp } from 'utils/constraints';
+import { LOADING, ERROR } from 'constants/status';
+import { useStatus, useForm, useValidation, useTextInputProps } from 'hooks';
 import { SIGNUP } from 'actions/actionTypes';
 
 const messages = defineMessages({
@@ -15,49 +15,65 @@ const messages = defineMessages({
   passConfirmation: { id: 'signup.form.passconfirmation' }
 });
 
-export const SignUpForm = ({ handleSubmit }) => {
+const fields = {
+  email: 'email',
+  password: 'password',
+  passwordConfirmation: 'passwordConfirmation'
+};
+
+export const SignUpForm = ({ onSubmit }) => {
   const intl = useIntl();
-  const loading = useLoading(SIGNUP);
+  const { status, error } = useStatus(SIGNUP);
+
+  const validator = useValidation(signUp);
+  const { values, errors, handleValueChange, handleSubmit, handleBlur } = useForm(
+    {
+      onSubmit,
+      validator,
+      validateOnBlur: true
+    },
+    [onSubmit]
+  );
+
+  const inputProps = useTextInputProps({ handleValueChange, handleBlur, values, errors });
 
   return (
     <form onSubmit={handleSubmit}>
+      {status === ERROR && <strong>{error}</strong>}
       <div>
-        <Field
+        <Input
           name="email"
           label={intl.formatMessage(messages.email)}
-          component={Input}
           type="email"
+          {...inputProps(fields.email)}
         />
       </div>
       <div>
-        <Field
+        <Input
           name="password"
           label={intl.formatMessage(messages.password)}
-          component={Input}
           type="password"
+          {...inputProps(fields.password)}
         />
       </div>
       <div>
-        <Field
+        <Input
           name="passwordConfirmation"
           label={intl.formatMessage(messages.passConfirmation)}
-          component={Input}
           type="password"
+          {...inputProps(fields.passwordConfirmation)}
         />
       </div>
       <button type="submit">
         <FormattedMessage id="login.form.submit" />
       </button>
-      {loading && <Loading />}
+      {status === LOADING && <Loading />}
     </form>
   );
 };
 
 SignUpForm.propTypes = {
-  handleSubmit: func.isRequired
+  onSubmit: func.isRequired
 };
 
-export default reduxForm({
-  form: 'signUp',
-  validate: validations(signUp, { fullMessages: false })
-})(memo(SignUpForm));
+export default memo(SignUpForm);

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -2,3 +2,6 @@ export { default as useSession } from './useSession';
 export { default as useDispatch } from './useDispatch';
 export { default as useLoading } from './useLoading';
 export { default as useStatus } from './useStatus';
+export { default as useForm } from './useForm';
+export { default as useValidation } from './useValidation';
+export { default as useTextInputProps } from './useTextInputProps';

--- a/src/hooks/useDispatch.js
+++ b/src/hooks/useDispatch.js
@@ -3,5 +3,6 @@ import { useDispatch } from 'react-redux';
 
 export default (action, ...dependencies) => {
   const dispatch = useDispatch();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   return useCallback(payload => dispatch(action(payload)), [dispatch, action, ...dependencies]);
 };

--- a/src/hooks/useForm.js
+++ b/src/hooks/useForm.js
@@ -1,0 +1,84 @@
+import { useState, useCallback } from 'react';
+
+const useForm = (
+  {
+    initialValues = {},
+    onSubmit,
+    validator = () => {},
+    validateOnChange = true,
+    validateOnBlur = false
+  },
+  ...dependencies
+) => {
+  const [values, setValues] = useState(initialValues);
+  const [errors, setErrors] = useState({});
+  const [blurredFields, setBlurredFields] = useState({});
+
+  const handleSubmit = useCallback(
+    event => {
+      event.preventDefault();
+      const newErrors = validator(values) || {};
+      const valid = !Object.values(newErrors)
+        .filter(error => !!error)
+        .flat().length;
+      if (valid) {
+        onSubmit(values);
+      } else {
+        setErrors(newErrors);
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [values, setErrors, validator, onSubmit, ...dependencies]
+  );
+
+  const runValidations = useCallback(
+    (newValues, key) => {
+      const validations = validator(newValues) || {};
+      if (key) {
+        setErrors({ ...errors, [key]: validations[key] });
+      } else {
+        setErrors(validator(newValues));
+      }
+    },
+    [validator, errors, setErrors]
+  );
+
+  const handleValueChange = useCallback(
+    (key, value) => {
+      const newValues = {
+        ...values,
+        [key]: value
+      };
+      setValues(newValues);
+      if (validateOnChange) {
+        runValidations(newValues, key);
+      }
+    },
+    [values, setValues, runValidations, validateOnChange]
+  );
+
+  const handleBlur = useCallback(
+    key => {
+      setBlurredFields({
+        ...blurredFields,
+        [key]: true
+      });
+      if (validateOnBlur) runValidations(values, key);
+    },
+    [blurredFields, setBlurredFields, runValidations, values, validateOnBlur]
+  );
+
+  return {
+    values,
+    setValues,
+    errors,
+    setErrors,
+    blurredFields,
+    setBlurredFields,
+    handleValueChange,
+    handleSubmit,
+    handleBlur
+  };
+};
+
+export default useForm;

--- a/src/hooks/useTextInputProps.js
+++ b/src/hooks/useTextInputProps.js
@@ -1,0 +1,12 @@
+import { useCallback } from 'react';
+
+export default ({ handleValueChange, handleBlur, values, errors }) =>
+  useCallback(
+    fieldKey => ({
+      value: values[fieldKey] || '',
+      onChange: ({ target: { value } }) => handleValueChange(fieldKey, value),
+      onBlur: () => handleBlur(fieldKey),
+      errors: errors[fieldKey]
+    }),
+    [handleBlur, handleValueChange, values, errors]
+  );

--- a/src/hooks/useValidation.js
+++ b/src/hooks/useValidation.js
@@ -1,0 +1,7 @@
+import { useCallback } from 'react';
+import validate from 'validate.js';
+
+validate.validators.presence.options = { allowEmpty: false };
+
+export default (constraints, options = { fullMessages: false }) =>
+  useCallback(values => validate(values, constraints, options), [constraints, options]);

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,5 +1,4 @@
 import { combineReducers } from 'redux';
-import { reducer as form } from 'redux-form';
 import { connectRouter } from 'connected-react-router';
 import localForage from 'localforage';
 import { persistReducer } from 'redux-persist';
@@ -17,7 +16,6 @@ const sessionPersistConfig = {
 
 const rootReducer = history =>
   combineReducers({
-    form,
     session: persistReducer(sessionPersistConfig, session),
     router: connectRouter(history),
     actionStatus

--- a/src/store/configureStore.dev.js
+++ b/src/store/configureStore.dev.js
@@ -15,8 +15,7 @@ import rootReducer from 'reducers';
 export default function configureStore(initialState) {
   const logger = createLogger({
     collapsed: true,
-    predicate: (getState, { type }) =>
-      !_.startsWith(type, '@@router') && !_.startsWith(type, '@@redux-form')
+    predicate: (getState, { type }) => !_.startsWith(type, '@@router')
   });
 
   const middewares = [thunkMiddleware, logger, routerMiddleware(history)];

--- a/yarn.lock
+++ b/yarn.lock
@@ -10251,22 +10251,6 @@ redent@^2.0.0:
     indent-string "^3.0.0"
     strip-indent "^2.0.0"
 
-redux-form@8.2.3:
-  version "8.2.3"
-  resolved "https://registry.yarnpkg.com/redux-form/-/redux-form-8.2.3.tgz#6156cddf15ad929cf70671607d3b980a81e94ec1"
-  integrity sha512-AHuhaAoG6bH6t9xfsZA6ZxK9M/QF0GN+AfoRaQzP5o+ZINIiCEUS3ThgAEDbZPvqwuem/WQdtoc0P9HcXvEelA==
-  dependencies:
-    "@babel/runtime" "^7.2.0"
-    es6-error "^4.1.1"
-    hoist-non-react-statics "^3.2.1"
-    invariant "^2.2.4"
-    is-promise "^2.1.0"
-    lodash "^4.17.11"
-    lodash-es "^4.17.11"
-    prop-types "^15.6.1"
-    react-is "^16.7.0"
-    react-lifecycles-compat "^3.0.4"
-
 redux-logger@3.0.6:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/redux-logger/-/redux-logger-3.0.6.tgz#f7555966f3098f3c88604c449cf0baf5778274bf"


### PR DESCRIPTION
Replaces redux-form with the useForm hooks from react-native-base.
Just some small adjustments:
- `onChangeText` had to be converted to `onChange` and the event object had to be deconstructed.
- Used `{ fullMessages: false }` as default option on the validation hook, since that was what we were using.

This PR made me think think that we should really get our error handling together...
For more info check: https://github.com/rootstrap/react-native-base/pull/86