### PR TITLE
Yay! No more double semis

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -45,7 +45,6 @@
     "no-console": [1, { "allow": ["warn", "error"] }],
     "no-debugger": 1,
     "no-var": 1,
-    "semi": [1, "always"],
     "no-trailing-spaces": 1,
     "eol-last": 1,
     "no-underscore-dangle": 0,


### PR DESCRIPTION
If you were using auto-fix on save you were probably wondering why 2 semi-colons where being added instead of one.
The eslint rule is redundant since prettier has this already.