### PR TITLE
Use shallow equal

### DIFF
--- a/src/hooks/useSession.js
+++ b/src/hooks/useSession.js
@@ -2,9 +2,9 @@ import { useSelector, shallowEqual } from 'react-redux';
 
 const useSession = () =>
   useSelector(
-    ({ session }) => ({
-      authenticated: session.authenticated,
-      user: session.user
+    ({ session: { authenticated, user } }) => ({
+      authenticated,
+      user
     }),
     shallowEqual
   );

--- a/src/hooks/useSession.js
+++ b/src/hooks/useSession.js
@@ -1,9 +1,12 @@
-import { useSelector } from 'react-redux';
+import { useSelector, shallowEqual } from 'react-redux';
 
 const useSession = () =>
-  useSelector(({ session }) => ({
-    authenticated: session.authenticated,
-    user: session.user
-  }));
+  useSelector(
+    ({ session }) => ({
+      authenticated: session.authenticated,
+      user: session.user
+    }),
+    shallowEqual
+  );
 
 export default useSession;


### PR DESCRIPTION
## Use shallow equal

### Description 
This was causing unnecessary renders. We update the session in every authenticated request, since almost always the token we save from the request is the same we already have stored, we can check this before updating it. We can use shallow equal in useSession so it compares on object keys (not deep) and avoid re-computing and re-rendering the component. 