### PR TITLE
Add useSelectOptions hook

### DIFF
--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -3,3 +3,4 @@ export { default as useDispatch } from './useDispatch';
 export { default as useForm } from './useForm';
 export { default as useValidation } from './useValidation';
 export { default as useTextInputProps } from './useTextInputProps';
+export { default as useSelectOptions } from './useSelectOptions';

--- a/src/hooks/useSelectOptions.js
+++ b/src/hooks/useSelectOptions.js
@@ -1,0 +1,8 @@
+import { useMemo } from 'react';
+
+export default (items, labelAttribute = 'name', valueAttribute = 'id') =>
+  useMemo(() => items.map(item => ({ label: item[labelAttribute], value: item[valueAttribute] })), [
+    items,
+    labelAttribute,
+    valueAttribute
+  ]);


### PR DESCRIPTION
This PR adds a new hook called `useSelectOptions`, it helps reduce the amount of code needed when having to map a list of objects to use in a select.

#### Usage:
```js
const options = useSelectOptions(items); //  when item is { id, name }
const options = useSelectOptions(items, 'title'); // if the label attribute is not name
const options = useSelectOptions(items, 'name', 'type'); // if the value attibute is not id
```

Even though we don't have any selects in the base, it can be useful and it will be nice to add it. This hook has already been used in a couple of projects already. And has been accepted in the 
`react-native-base`.