### PR TITLE
Move linters to Code Climate

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,9 +24,6 @@ jobs:
       - run:
           name: Run Jest tests
           command: yarn jest src
-      - run:
-          name: Run linter
-          command: yarn lint
       - save_cache:
           key: dependency-cache-{{ checksum "yarn.lock" }}
           paths:

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -54,6 +54,10 @@ plugins:
     enabled: true
     config:
       config: ~/.eslintrc
+  nodesecurity:
+    enabled: true
+  stylelint:
+    enabled: true 
 exclude_patterns:
   - "dist/"
   - "server/build/"


### PR DESCRIPTION
We discussed this on the Code Quality group that it would be better to centralize code quality checks like linters and other tools in Code Climate like we are doing with the other technologies (Rails, iOS and Android)