### PR TITLE
Fix RouteFromPath

### DIFF
--- a/src/components/routes/PrivateRoute.js
+++ b/src/components/routes/PrivateRoute.js
@@ -1,16 +1,14 @@
 import React from 'react';
-import { bool, string, node } from 'prop-types';
+import { bool, string, elementType } from 'prop-types';
 import { Route, Redirect, useLocation } from 'react-router-dom';
 
 import routes from 'constants/routesPaths';
 
-const PrivateRoute = ({ children, exact = false, path, authenticated }) => {
+const PrivateRoute = ({ authenticated, ...route }) => {
   const location = useLocation();
 
   return authenticated ? (
-    <Route exact={exact} path={path}>
-      {children}
-    </Route>
+    <Route {...route} />
   ) : (
     <Redirect
       to={{
@@ -22,7 +20,7 @@ const PrivateRoute = ({ children, exact = false, path, authenticated }) => {
 };
 
 PrivateRoute.propTypes = {
-  children: node.isRequired,
+  component: elementType.isRequired,
   path: string.isRequired,
   authenticated: bool.isRequired,
   exact: bool

--- a/src/components/routes/RouteFromPath.js
+++ b/src/components/routes/RouteFromPath.js
@@ -1,18 +1,15 @@
 import React from 'react';
 import { Route } from 'react-router-dom';
-import { node } from 'prop-types';
+import { elementType, bool } from 'prop-types';
 
 import PrivateRoute from './PrivateRoute';
 
-const RouteFromPath = ({ component, ...route }) =>
-  route.private ? (
-    <PrivateRoute {...route}>{component}</PrivateRoute>
-  ) : (
-    <Route {...route}>{component}</Route>
-  );
+const RouteFromPath = ({ needsAuth, ...route }) =>
+  needsAuth ? <PrivateRoute {...route} /> : <Route {...route} />;
 
 RouteFromPath.propTypes = {
-  component: node.isRequired
+  component: elementType.isRequired,
+  needsAuth: bool
 };
 
 export default RouteFromPath;

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import routesPaths from 'constants/routesPaths';
 import HomePage from 'pages/HomePage';
 import LoginPage from 'pages/LoginPage';
@@ -9,20 +7,20 @@ import NotFoundPage from 'pages/NotFoundPage';
 const routes = [
   {
     path: routesPaths.index,
-    component: <HomePage />,
+    component: HomePage,
     exact: true,
-    private: true
+    needsAuth: true
   },
   {
     path: routesPaths.login,
-    component: <LoginPage />
+    component: LoginPage
   },
   {
     path: routesPaths.signUp,
-    component: <SignUpPage />
+    component: SignUpPage
   },
   {
-    component: <NotFoundPage />
+    component: NotFoundPage
   }
 ];
 


### PR DESCRIPTION
Passing a component as children to a route is not supported by `react-router`. This is a better way. (Will maintain route props and inject them in the component)

**Note:** `changed` private to `needsAuth` because the linter said `private` is a reserved word in strict mode. If you cna think o fa better name please elt me know. ps: protected is reserved too.