### PR TITLE
Fix lint-staged linting unstaged files

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   "lint-staged": {
     "src/**/*.{js,jsx,ts,tsx,json}": [
       "prettier --write",
-      "eslint --fix webpack/webpack.config.* src",
+      "eslint --fix",
       "git add"
     ]
   },


### PR DESCRIPTION
Lint staged automatically passes a file/glob to the commands specified. Our rule in `package.json` was adding a file and a glob so it was linting unstaged files.