### PR TITLE
Add default value to headers

### DIFF
--- a/server/helpers.js
+++ b/server/helpers.js
@@ -1,4 +1,4 @@
-export const getLanguageFromHeader = header => {
+export const getLanguageFromHeader = (header = 'en-US') => {
   const supportedLangages = ['en', 'es'];
   const languages = header.split(';');
 


### PR DESCRIPTION
This PR includes:

- When using curl, Postman or crawlers we don't receive any header, so when trying to use split function it return undefined. 