### PR TITLE
Remove unnecesary babel configuration

### DIFF
--- a/webpack/webpack.config.client.js
+++ b/webpack/webpack.config.client.js
@@ -6,8 +6,6 @@ import path from 'path';
 import Dotenv from 'dotenv-webpack';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
 import { GenerateSW } from 'workbox-webpack-plugin';
-import 'core-js/stable';
-import 'regenerator-runtime/runtime';
 
 import resolve from './shared/resolve';
 
@@ -20,7 +18,7 @@ const GLOBALS = {
 export default {
   resolve,
   devtool: 'source-map',
-  entry: ['@babel/polyfill', path.resolve(__dirname, '../server/client')],
+  entry: [path.resolve(__dirname, '../server/client')],
   target: 'web',
   mode: 'production',
   output: {

--- a/webpack/webpack.config.cypress.js
+++ b/webpack/webpack.config.cypress.js
@@ -2,7 +2,6 @@ const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const path = require('path');
 const Dotenv = require('dotenv-webpack');
-
 const resolve = require('./shared/resolve');
 
 const GLOBALS = {
@@ -15,7 +14,6 @@ module.exports = {
   resolve,
   devtool: 'eval-source-map',
   entry: [
-    '@babel/polyfill',
     'react-hot-loader/patch',
     './src/webpack-public-path',
     'webpack-hot-middleware/client?reload=true',

--- a/webpack/webpack.config.dev.js
+++ b/webpack/webpack.config.dev.js
@@ -2,7 +2,6 @@ import webpack from 'webpack';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
 import path from 'path';
 import Dotenv from 'dotenv-webpack';
-
 import resolve from './shared/resolve';
 
 const GLOBALS = {
@@ -15,7 +14,6 @@ export default {
   resolve,
   devtool: 'eval-source-map',
   entry: [
-    '@babel/polyfill',
     './src/webpack-public-path',
     'webpack-hot-middleware/client?reload=true',
     path.resolve(__dirname, '../src/index.js')

--- a/webpack/webpack.config.prod.js
+++ b/webpack/webpack.config.prod.js
@@ -7,8 +7,6 @@ import path from 'path';
 import CompressionPlugin from 'compression-webpack-plugin';
 import { GenerateSW } from 'workbox-webpack-plugin';
 import dotenv from 'dotenv';
-import 'core-js/stable';
-import 'regenerator-runtime/runtime';
 
 import resolve from './shared/resolve';
 
@@ -24,7 +22,7 @@ const GLOBALS = {
 export default {
   resolve,
   devtool: 'source-map',
-  entry: ['@babel/polyfill', path.resolve(__dirname, '../src/index')],
+  entry: [path.resolve(__dirname, '../src/index')],
   target: 'web',
   mode: 'production',
   output: {

--- a/webpack/webpack.config.server.js
+++ b/webpack/webpack.config.server.js
@@ -3,8 +3,6 @@ import MiniCssExtractPlugin from 'mini-css-extract-plugin';
 import path from 'path';
 import webpackNodeExternals from 'webpack-node-externals';
 import Dotenv from 'dotenv-webpack';
-import 'core-js/stable';
-import 'regenerator-runtime/runtime';
 
 import resolve from './shared/resolve';
 
@@ -18,7 +16,7 @@ const GLOBALS = {
 export default {
   resolve,
   devtool: 'source-map',
-  entry: ['@babel/polyfill', path.resolve(__dirname, '../server')],
+  entry: [path.resolve(__dirname, '../server')],
   target: 'node',
   mode: 'production',
   output: {


### PR DESCRIPTION
We have `babel` configured with `useBuiltIns` option in `usage` mode. This means that `webpack` detects when to add polyfills automatically, you don't need to import `core-js` and `regenerator-runtime`, `webpack` does it for you. If you manually import these, as we are doing now, is the same as using `useBuiltIns` option in `entry` mode, which means `import me all the polyfills whether we use it or not`, this is not what we want and increases the bundle size.

If you want to test this, you can run the `bundle-analyzer` to check that `core-js` imports and `regenerator-runtime` are still there. 

SOURCE: https://babeljs.io/docs/en/babel-preset-env#usebuiltins